### PR TITLE
Update ubuntu test to use Ubuntu 20.04 and 22.04

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,31 +1,31 @@
 name: Ubuntu
 on: [push]
 jobs:
-  ubuntu-16:
-    runs-on: ubuntu-16.04
+  ubuntu-20:
+    runs-on: ubuntu-20.04
     steps:
       # print Ubuntu version
       - run: cat /etc/lsb-release
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cypress run
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v5
         with:
           env: lastName=Smith
         env:
           CYPRESS_firstName: Joe
 
-  ubuntu-18:
-    runs-on: ubuntu-18.04
+  ubuntu-22:
+    runs-on: ubuntu-22.04
     steps:
       # print Ubuntu version
       - run: cat /etc/lsb-release
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cypress run
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v5
         with:
           env: lastName=Smith
         env:


### PR DESCRIPTION
This PR resolves issue https://github.com/bahmutov/cypress-gh-action-example/issues/68 "Example uses retired Ubuntu 16 and deprecated Ubuntu 18 runner"

It updates [.github/workflows/ubuntu.yml](https://github.com/bahmutov/cypress-gh-action-example/blob/master/.github/workflows/ubuntu.yml):

by removing

- ubuntu-16.04 (no longer available)
- ubuntu-18.04 (deprecated)

and replacing with

- ubuntu-20.04
- ubuntu-22.04

It also updates action versions to the latest versions.